### PR TITLE
Evoluir busca na barra de pesquisa

### DIFF
--- a/prisma/migrations/20260420150959_aprimora_busca/migration.sql
+++ b/prisma/migrations/20260420150959_aprimora_busca/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Candidato" ADD COLUMN     "resumo" TEXT;
+
+-- AlterTable
+ALTER TABLE "Vaga" ADD COLUMN     "resumo" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,7 @@ model Candidato {
   experiencias      Experiencia[]
   vagasRecomendadas Recomendacao[]
   embedding         Unsupported("vector(3072)")?
+  resumo            String?
 }
 
 enum PublicoAlvo {
@@ -120,6 +121,7 @@ model Vaga {
   conhecimentosOpcionais    String[]
   candidadosRecomendados    Recomendacao[]
   embedding                 Unsupported("vector(3072)")?
+  resumo                    String?
 }
 
 model Experiencia {

--- a/src/models/CandidatoSchema.ts
+++ b/src/models/CandidatoSchema.ts
@@ -27,6 +27,7 @@ const CandidatoSchema = z.object({
   linkedin: z.string().nullable(),
   areasInteresse: z.string().array(),
   habilidades: z.string().array(),
+  resumo: z.string().nullable(),
 });
 
 export const CandidadoEmbeddingSchema = CandidatoSchema.extend({

--- a/src/models/CandidatoSchema.ts
+++ b/src/models/CandidatoSchema.ts
@@ -27,7 +27,6 @@ const CandidatoSchema = z.object({
   linkedin: z.string().nullable(),
   areasInteresse: z.string().array(),
   habilidades: z.string().array(),
-  resumo: z.string().nullable(),
 });
 
 export const CandidadoEmbeddingSchema = CandidatoSchema.extend({
@@ -44,6 +43,7 @@ export const CandidatoUpdateSchema = CandidatoSchema.extend({
 
 export const CandidatoResponseSchema = CandidatoSchema.extend({
   id: z.number(),
+  resumo: z.string().nullable(),
   experiencias: z.array(z.lazy(() => ExperienciaResponseSchema)).optional(),
 });
 

--- a/src/models/ExperienciaSchema.ts
+++ b/src/models/ExperienciaSchema.ts
@@ -20,3 +20,4 @@ export const ExperienciaResponseSchema = ExperienciaSchema.extend({
 
 export type ExperienciaCreateDTO = z.infer<typeof ExperienciaCreateSchema>;
 export type ExperienciaUpdateDTO = z.infer<typeof ExperienciaUpdateSchema>;
+export type ExperienciaResponseDTO = z.infer<typeof ExperienciaResponseSchema>;

--- a/src/models/ExperienciaSchema.ts
+++ b/src/models/ExperienciaSchema.ts
@@ -20,4 +20,3 @@ export const ExperienciaResponseSchema = ExperienciaSchema.extend({
 
 export type ExperienciaCreateDTO = z.infer<typeof ExperienciaCreateSchema>;
 export type ExperienciaUpdateDTO = z.infer<typeof ExperienciaUpdateSchema>;
-export type ExperienciaResponseDTO = z.infer<typeof ExperienciaResponseSchema>;

--- a/src/models/VagaSchema.ts
+++ b/src/models/VagaSchema.ts
@@ -30,7 +30,6 @@ const VagaSchema = z.object({
   publicoAlvo: PublicoAlvo.array(),
   conhecimentosObrigatorios: z.string().array(),
   conhecimentosOpcionais: z.string().array(),
-  resumo: z.string().nullable(),
 });
 
 export const VagaSchemaEmbedding = VagaSchema.extend({
@@ -46,6 +45,7 @@ export const VagaUpdateSchema = VagaSchema.partial();
 export const VagaResponseSchema = VagaSchema.extend({
   id: z.number(),
   recrutador: RecrutadorExtendedResponseSchema,
+  resumo: z.string().nullable(),
 });
 
 export type VagaCreateDTO = z.infer<typeof VagaCreateSchema>;

--- a/src/models/VagaSchema.ts
+++ b/src/models/VagaSchema.ts
@@ -30,6 +30,7 @@ const VagaSchema = z.object({
   publicoAlvo: PublicoAlvo.array(),
   conhecimentosObrigatorios: z.string().array(),
   conhecimentosOpcionais: z.string().array(),
+  resumo: z.string().nullable(),
 });
 
 export const VagaSchemaEmbedding = VagaSchema.extend({

--- a/src/repositories/CandidatoRepository.ts
+++ b/src/repositories/CandidatoRepository.ts
@@ -4,20 +4,21 @@ import { CandidatoCreateDTO, CandidatoUpdateDTO } from '../models/CandidatoSchem
 import { perfilRepository } from './PerfilRepositoy';
 import prisma from '../utils/prisma';
 import { Filter, Sorter, buildWhereClause, buildOrderClause } from '../utils/filterUtils';
-import { camposCandidato, gerarEmbeddingCandidato } from '../utils/matchUtils';
+import { camposCandidato, gerarEmbeddingCandidato, gerarResumoCandidato } from '../utils/matchUtils';
 import { recomendacaoRepository } from './RecomendacaoRepository';
 
 class CandidatoRepository {
   async create(data: CandidatoCreateDTO) {
     const { perfil, ...candidato } = data;
     return prisma.$transaction(async tx => {
+      const resumoCandidato = gerarResumoCandidato(data);
       const perfilCriado = await perfilRepository.create(tx, perfil, TipoPerfil.CANDIDATO);
       const candidatoCriado = await tx.candidato.create({
-        data: { ...candidato, perfil: { connect: { id: perfilCriado.id } } },
+        data: { ...candidato, perfil: { connect: { id: perfilCriado.id } }, resumo: resumoCandidato },
         include: { perfil: true },
       });
 
-      await gerarEmbeddingCandidato(tx, candidatoCriado);
+      await gerarEmbeddingCandidato(tx, candidatoCriado, resumoCandidato);
       return candidatoCriado;
     });
   }
@@ -40,19 +41,20 @@ class CandidatoRepository {
   async update(id: number, data: CandidatoUpdateDTO) {
     const { perfil, ...candidato } = data;
     return prisma.$transaction(async tx => {
+      const candidatoAtual = await tx.candidato.findUniqueOrThrow({ where: { id }, include: { perfil: true } });
+      const dadosFiltrados = Object.fromEntries(Object.entries(candidato).filter(([, v]) => v !== undefined));
+      const candidatoCompleto: CandidatoCreateDTO = { ...candidatoAtual, ...dadosFiltrados } as CandidatoCreateDTO;
+      const resumoCandidato = gerarResumoCandidato(candidatoCompleto);
       const candidatoAtualizado = await tx.candidato.update({
         where: { id },
-        data: {
-          ...candidato,
-          ...{ perfil: { update: perfil } },
-        },
+        data: { ...candidato, ...{ perfil: { update: perfil } }, resumo: resumoCandidato },
         include: { perfil: true, experiencias: true },
       });
 
       const camposModificados = camposCandidato.some(campo => data[campo as keyof typeof data] !== undefined);
 
       if (camposModificados) {
-        await gerarEmbeddingCandidato(tx, candidatoAtualizado);
+        await gerarEmbeddingCandidato(tx, candidatoAtualizado, resumoCandidato);
       }
 
       return candidatoAtualizado;

--- a/src/repositories/CandidatoRepository.ts
+++ b/src/repositories/CandidatoRepository.ts
@@ -4,7 +4,7 @@ import { CandidatoCreateDTO, CandidatoUpdateDTO } from '../models/CandidatoSchem
 import { perfilRepository } from './PerfilRepositoy';
 import prisma from '../utils/prisma';
 import { Filter, Sorter, buildWhereClause, buildOrderClause } from '../utils/filterUtils';
-import { camposCandidato, gerarEmbeddingCandidato, gerarResumoCandidato } from '../utils/matchUtils';
+import { atualizaResumoCandidato, gerarEmbeddingCandidato, gerarResumoCandidato } from '../utils/matchUtils';
 import { recomendacaoRepository } from './RecomendacaoRepository';
 
 class CandidatoRepository {
@@ -41,22 +41,16 @@ class CandidatoRepository {
   async update(id: number, data: CandidatoUpdateDTO) {
     const { perfil, ...candidato } = data;
     return prisma.$transaction(async tx => {
-      const candidatoAtual = await tx.candidato.findUniqueOrThrow({ where: { id }, include: { perfil: true } });
-      const dadosFiltrados = Object.fromEntries(Object.entries(candidato).filter(([, v]) => v !== undefined));
-      const candidatoCompleto: CandidatoCreateDTO = { ...candidatoAtual, ...dadosFiltrados } as CandidatoCreateDTO;
-      const resumoCandidato = gerarResumoCandidato(candidatoCompleto);
-      const candidatoAtualizado = await tx.candidato.update({
+      await tx.candidato.update({
         where: { id },
-        data: { ...candidato, ...{ perfil: { update: perfil } }, resumo: resumoCandidato },
+        data: {
+          ...candidato,
+          ...{ perfil: { update: perfil } },
+        },
         include: { perfil: true, experiencias: true },
       });
 
-      const camposModificados = camposCandidato.some(campo => data[campo as keyof typeof data] !== undefined);
-
-      if (camposModificados) {
-        await gerarEmbeddingCandidato(tx, candidatoAtualizado, resumoCandidato);
-      }
-
+      const candidatoAtualizado = await atualizaResumoCandidato(tx, id);
       return candidatoAtualizado;
     });
   }

--- a/src/repositories/CandidatoRepository.ts
+++ b/src/repositories/CandidatoRepository.ts
@@ -4,7 +4,12 @@ import { CandidatoCreateDTO, CandidatoUpdateDTO } from '../models/CandidatoSchem
 import { perfilRepository } from './PerfilRepositoy';
 import prisma from '../utils/prisma';
 import { Filter, Sorter, buildWhereClause, buildOrderClause } from '../utils/filterUtils';
-import { atualizaResumoCandidato, gerarEmbeddingCandidato, gerarResumoCandidato } from '../utils/matchUtils';
+import {
+  atualizaResumoCandidato,
+  camposCandidato,
+  gerarEmbeddingCandidato,
+  gerarResumoCandidato,
+} from '../utils/matchUtils';
 import { recomendacaoRepository } from './RecomendacaoRepository';
 
 class CandidatoRepository {
@@ -41,7 +46,7 @@ class CandidatoRepository {
   async update(id: number, data: CandidatoUpdateDTO) {
     const { perfil, ...candidato } = data;
     return prisma.$transaction(async tx => {
-      await tx.candidato.update({
+      let candidatoAtualizado = await tx.candidato.update({
         where: { id },
         data: {
           ...candidato,
@@ -50,7 +55,15 @@ class CandidatoRepository {
         include: { perfil: true, experiencias: true },
       });
 
-      const candidatoAtualizado = await atualizaResumoCandidato(tx, id);
+      const camposModificados = camposCandidato.some(campo => data[campo as keyof typeof data] !== undefined);
+
+      if (camposModificados) {
+        const candidatoComResumo = await atualizaResumoCandidato(tx, id);
+        if (candidatoComResumo) {
+          candidatoAtualizado = { ...candidatoAtualizado, ...candidatoComResumo };
+        }
+      }
+
       return candidatoAtualizado;
     });
   }

--- a/src/repositories/ExperienciaRepository.ts
+++ b/src/repositories/ExperienciaRepository.ts
@@ -1,5 +1,5 @@
 import { ExperienciaCreateDTO, ExperienciaUpdateDTO } from '../models/ExperienciaSchema';
-import { gerarResumoExperiencia } from '../utils/matchUtils';
+import { atualizaResumoCandidato } from '../utils/matchUtils';
 import prisma from '../utils/prisma';
 
 class ExperienciaRepository {
@@ -8,7 +8,7 @@ class ExperienciaRepository {
       const experienciaCriada = await tx.experiencia.create({
         data: { ...data, candidatoId },
       });
-      await gerarResumoExperiencia(tx, candidatoId);
+      await atualizaResumoCandidato(tx, candidatoId);
       return experienciaCriada;
     });
   }
@@ -29,7 +29,7 @@ class ExperienciaRepository {
         where: { id },
         data: Object.fromEntries(Object.entries(data).filter(([, v]) => v !== undefined)),
       });
-      await gerarResumoExperiencia(tx, experienciaAtualizada.candidatoId);
+      await atualizaResumoCandidato(tx, experienciaAtualizada.candidatoId);
       return experienciaAtualizada;
     });
   }
@@ -39,7 +39,7 @@ class ExperienciaRepository {
       const experienciaDeletada = await tx.experiencia.delete({
         where: { id },
       });
-      await gerarResumoExperiencia(tx, experienciaDeletada.candidatoId);
+      await atualizaResumoCandidato(tx, experienciaDeletada.candidatoId);
       return experienciaDeletada;
     });
   }

--- a/src/repositories/ExperienciaRepository.ts
+++ b/src/repositories/ExperienciaRepository.ts
@@ -1,4 +1,5 @@
 import { ExperienciaCreateDTO, ExperienciaUpdateDTO } from '../models/ExperienciaSchema';
+import { gerarResumoExperiencia } from '../utils/matchUtils';
 import prisma from '../utils/prisma';
 
 class ExperienciaRepository {
@@ -7,6 +8,7 @@ class ExperienciaRepository {
       const experienciaCriada = await tx.experiencia.create({
         data: { ...data, candidatoId },
       });
+      await gerarResumoExperiencia(tx, experienciaCriada, candidatoId);
       return experienciaCriada;
     });
   }

--- a/src/repositories/ExperienciaRepository.ts
+++ b/src/repositories/ExperienciaRepository.ts
@@ -8,7 +8,7 @@ class ExperienciaRepository {
       const experienciaCriada = await tx.experiencia.create({
         data: { ...data, candidatoId },
       });
-      await gerarResumoExperiencia(tx, experienciaCriada, candidatoId);
+      await gerarResumoExperiencia(tx, candidatoId);
       return experienciaCriada;
     });
   }
@@ -24,15 +24,23 @@ class ExperienciaRepository {
   }
 
   async update(id: number, data: ExperienciaUpdateDTO) {
-    return prisma.experiencia.update({
-      where: { id },
-      data: Object.fromEntries(Object.entries(data).filter(([, v]) => v !== undefined)),
+    return prisma.$transaction(async tx => {
+      const experienciaAtualizada = await tx.experiencia.update({
+        where: { id },
+        data: Object.fromEntries(Object.entries(data).filter(([, v]) => v !== undefined)),
+      });
+      await gerarResumoExperiencia(tx, experienciaAtualizada.candidatoId);
+      return experienciaAtualizada;
     });
   }
 
   async delete(id: number) {
-    return prisma.experiencia.delete({
-      where: { id },
+    return prisma.$transaction(async tx => {
+      const experienciaDeletada = await tx.experiencia.delete({
+        where: { id },
+      });
+      await gerarResumoExperiencia(tx, experienciaDeletada.candidatoId);
+      return experienciaDeletada;
     });
   }
 }

--- a/src/repositories/VagaRepository.ts
+++ b/src/repositories/VagaRepository.ts
@@ -1,18 +1,19 @@
 import { VagaCreateDTO, VagaUpdateDTO } from '../models/VagaSchema';
 import prisma from '../utils/prisma';
 import { Filter, Sorter, buildWhereClause, buildOrderClause } from '../utils/filterUtils';
-import { camposVaga, gerarEmbeddingVaga } from '../utils/matchUtils';
+import { camposVaga, gerarEmbeddingVaga, gerarResumoVaga } from '../utils/matchUtils';
 import { recomendacaoRepository } from './RecomendacaoRepository';
 
 class VagaRepository {
   async create(data: VagaCreateDTO, recrutadorId: number) {
     return prisma.$transaction(async tx => {
+      const resumoVaga = await gerarResumoVaga(data);
       const vagaCriada = await tx.vaga.create({
-        data: { ...data, recrutadorId },
+        data: { ...data, recrutadorId, resumo: resumoVaga },
         include: { recrutador: { include: { perfil: true } } },
       });
 
-      await gerarEmbeddingVaga(tx, vagaCriada);
+      await gerarEmbeddingVaga(tx, vagaCriada, resumoVaga);
       return vagaCriada;
     });
   }
@@ -34,18 +35,20 @@ class VagaRepository {
 
   async update(id: number, data: VagaUpdateDTO) {
     return prisma.$transaction(async tx => {
+      const vagaAtual = await tx.vaga.findUniqueOrThrow({ where: { id } });
+      const dadosFiltrados = Object.fromEntries(Object.entries(data).filter(([, v]) => v !== undefined));
+      const vagaCompleta: VagaCreateDTO = { ...vagaAtual, ...dadosFiltrados } as VagaCreateDTO;
+      const resumoVaga = await gerarResumoVaga(vagaCompleta);
       const vagaAtualizada = await tx.vaga.update({
         where: { id },
-        data: Object.fromEntries(Object.entries(data).filter(([, v]) => v !== undefined)),
+        data: { ...dadosFiltrados, resumo: resumoVaga },
         include: { recrutador: { include: { perfil: true } } },
       });
 
       const camposModificados = camposVaga.some(campo => data[campo as keyof typeof data] !== undefined);
-
       if (camposModificados) {
-        await gerarEmbeddingVaga(tx, vagaAtualizada);
+        await gerarEmbeddingVaga(tx, vagaAtualizada, resumoVaga);
       }
-
       return vagaAtualizada;
     });
   }

--- a/src/repositories/VagaRepository.ts
+++ b/src/repositories/VagaRepository.ts
@@ -7,7 +7,7 @@ import { recomendacaoRepository } from './RecomendacaoRepository';
 class VagaRepository {
   async create(data: VagaCreateDTO, recrutadorId: number) {
     return prisma.$transaction(async tx => {
-      const resumoVaga = await gerarResumoVaga(data);
+      const resumoVaga = gerarResumoVaga(data);
       const vagaCriada = await tx.vaga.create({
         data: { ...data, recrutadorId, resumo: resumoVaga },
         include: { recrutador: { include: { perfil: true } } },
@@ -38,7 +38,7 @@ class VagaRepository {
       const vagaAtual = await tx.vaga.findUniqueOrThrow({ where: { id } });
       const dadosFiltrados = Object.fromEntries(Object.entries(data).filter(([, v]) => v !== undefined));
       const vagaCompleta: VagaCreateDTO = { ...vagaAtual, ...dadosFiltrados } as VagaCreateDTO;
-      const resumoVaga = await gerarResumoVaga(vagaCompleta);
+      const resumoVaga = gerarResumoVaga(vagaCompleta);
       const vagaAtualizada = await tx.vaga.update({
         where: { id },
         data: { ...dadosFiltrados, resumo: resumoVaga },

--- a/src/utils/matchUtils.ts
+++ b/src/utils/matchUtils.ts
@@ -89,27 +89,27 @@ export async function gerarEmbeddingVaga(tx: Prisma.TransactionClient, vaga: Vag
   await atualizarEmbedding(tx, 'Vaga', vaga.id, embedding.values);
 }
 
-export async function gerarResumoExperiencia(
-  tx: Prisma.TransactionClient,
-  experiencia: ExperienciaResponseDTO,
-  candidatoId: number,
-) {
-  const { titulo, descricao, orientador, instituicao, periodoInicio, periodoFim, local } = experiencia;
-  const resumo = `O candidato possui experiência de ${titulo} na instituição ${instituicao}, orientada por ${orientador}. Descrição da experiência: ${descricao}. Atuou no Período: ${periodoInicio} a ${periodoFim ? periodoFim : 'atualmente'}. Local da experiência: ${local}.`;
-
-  await atualizarResumoCandidato(tx, candidatoId, resumo);
-}
-
-async function atualizarResumoCandidato(tx: Prisma.TransactionClient, candidatoId: number, resumo: string) {
-  const candidato = await prisma.candidato.findUnique({ where: { id: candidatoId }, include: { perfil: true } });
+export async function gerarResumoExperiencia(tx: Prisma.TransactionClient, candidatoId: number) {
+  const candidato = await tx.candidato.findUnique({ where: { id: candidatoId }, include: { perfil: true } });
   if (!candidato) return;
-  const resumoCandidato = `${candidato.resumo}\nExperiência: ${resumo}`;
+
+  const experiencias = await tx.experiencia.findMany({ where: { candidatoId } });
+  const resumoExperiencias = experiencias
+    .map(exp => {
+      return `O candidato possui experiência de ${exp.titulo} na instituição ${exp.instituicao}, orientada por ${exp.orientador}. 
+      Descrição da experiência: ${exp.descricao}. Atuou no período: ${exp.periodoInicio} a ${exp.periodoFim ?? 'atualmente'}. 
+      Local da experiência: ${exp.local}.`;
+    })
+    .join('\n');
+
+  const resumoFinal = `${candidato.resumo}\n${resumoExperiencias}`.trim();
   const candidatoAtualizado = await tx.candidato.update({
     where: { id: candidatoId },
-    data: { resumo: resumoCandidato },
+    data: { resumo: resumoFinal },
     include: { perfil: true },
   });
-  gerarEmbeddingCandidato(tx, candidatoAtualizado, resumoCandidato);
+
+  await gerarEmbeddingCandidato(tx, candidatoAtualizado, resumoFinal);
 }
 
 async function criarEmbedding(texto: string) {

--- a/src/utils/matchUtils.ts
+++ b/src/utils/matchUtils.ts
@@ -2,7 +2,7 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 import { Prisma } from '@prisma/client';
 
 import prisma from './prisma';
-import { VagaResponseDTO } from '../models/VagaSchema';
+import { VagaCreateDTO, VagaResponseDTO } from '../models/VagaSchema';
 import { CandidatoExtendedResponseDTO } from '../models/CandidatoSchema';
 
 export interface Similaridade {
@@ -55,7 +55,7 @@ export async function gerarEmbeddingCandidato(tx: Prisma.TransactionClient, cand
   await atualizarEmbedding(tx, 'Candidato', candidato.id, embedding.values);
 }
 
-export async function gerarEmbeddingVaga(tx: Prisma.TransactionClient, vaga: VagaResponseDTO) {
+export async function gerarResumoVaga(vaga: VagaCreateDTO) {
   const {
     titulo,
     descricao,
@@ -68,10 +68,14 @@ export async function gerarEmbeddingVaga(tx: Prisma.TransactionClient, vaga: Vag
     conhecimentosOpcionais,
   } = vaga;
 
-  const textoEmbedding = `Oportunidade de ${titulo} na instituição ${instituicao}. Perfil da Vaga: ${descricao}.
+  const resumo = `Oportunidade de ${titulo} na instituição ${instituicao}. Perfil da Vaga: ${descricao}.
     Formação requerida: ${curso} para o público ${publicoAlvo.join(', ')}. Requisitos técnicos mandatórios: ${conhecimentosObrigatorios.join(', ')}.
     Desejável e diferenciais: ${conhecimentosOpcionais.join(', ')}. Condições: Carga horária de ${cargaHoraria} e duração de ${duracao}.`;
 
+  return resumo;
+}
+
+export async function gerarEmbeddingVaga(tx: Prisma.TransactionClient, vaga: VagaResponseDTO, textoEmbedding: string) {
   const embedding = await criarEmbedding(textoEmbedding);
   await atualizarEmbedding(tx, 'Vaga', vaga.id, embedding.values);
 }

--- a/src/utils/matchUtils.ts
+++ b/src/utils/matchUtils.ts
@@ -3,7 +3,7 @@ import { Prisma } from '@prisma/client';
 
 import prisma from './prisma';
 import { VagaCreateDTO, VagaResponseDTO } from '../models/VagaSchema';
-import { CandidatoExtendedResponseDTO } from '../models/CandidatoSchema';
+import { CandidatoCreateDTO, CandidatoExtendedResponseDTO } from '../models/CandidatoSchema';
 
 export interface Similaridade {
   id: number;
@@ -35,7 +35,7 @@ export const camposCandidato = [
   'habilidades',
 ];
 
-export async function gerarEmbeddingCandidato(tx: Prisma.TransactionClient, candidato: CandidatoExtendedResponseDTO) {
+export function gerarResumoCandidato(candidato: CandidatoCreateDTO) {
   const {
     instituicao,
     areaAtuacao,
@@ -46,16 +46,24 @@ export async function gerarEmbeddingCandidato(tx: Prisma.TransactionClient, cand
     habilidades,
   } = candidato;
 
-  const textoEmbedding = `Profissional/Estudante da instituição ${instituicao} com foco em ${areaAtuacao}. 
+  const resumo = `Profissional/Estudante da instituição ${instituicao} com foco em ${areaAtuacao}. 
     Nível de escolaridade: ${nivelEscolaridade}, com conclusão prevista para ${periodoConclusao ?? 'não informada'}. 
     Competências e conhecimentos técnicos: ${habilidades.join(', ')}. Áreas de interesse e objetivos: ${areasInteresse.join(', ')}.
     Disponibilidade de tempo: ${tempoDisponivel}.`;
 
+  return resumo;
+}
+
+export async function gerarEmbeddingCandidato(
+  tx: Prisma.TransactionClient,
+  candidato: CandidatoExtendedResponseDTO,
+  textoEmbedding: string,
+) {
   const embedding = await criarEmbedding(textoEmbedding);
   await atualizarEmbedding(tx, 'Candidato', candidato.id, embedding.values);
 }
 
-export async function gerarResumoVaga(vaga: VagaCreateDTO) {
+export function gerarResumoVaga(vaga: VagaCreateDTO) {
   const {
     titulo,
     descricao,

--- a/src/utils/matchUtils.ts
+++ b/src/utils/matchUtils.ts
@@ -4,7 +4,6 @@ import { Prisma } from '@prisma/client';
 import prisma from './prisma';
 import { VagaCreateDTO, VagaResponseDTO } from '../models/VagaSchema';
 import { CandidatoCreateDTO, CandidatoExtendedResponseDTO } from '../models/CandidatoSchema';
-import { ExperienciaResponseDTO } from '../models/ExperienciaSchema';
 
 export interface Similaridade {
   id: number;

--- a/src/utils/matchUtils.ts
+++ b/src/utils/matchUtils.ts
@@ -88,7 +88,7 @@ export async function gerarEmbeddingVaga(tx: Prisma.TransactionClient, vaga: Vag
   await atualizarEmbedding(tx, 'Vaga', vaga.id, embedding.values);
 }
 
-export async function gerarResumoExperiencia(tx: Prisma.TransactionClient, candidatoId: number) {
+export async function atualizaResumoCandidato(tx: Prisma.TransactionClient, candidatoId: number) {
   const candidato = await tx.candidato.findUnique({ where: { id: candidatoId }, include: { perfil: true } });
   if (!candidato) return;
 
@@ -101,7 +101,7 @@ export async function gerarResumoExperiencia(tx: Prisma.TransactionClient, candi
     })
     .join('\n');
   const resumoBase = gerarResumoCandidato(candidato);
-  const resumoFinal = `${resumoBase}\n${resumoExperiencias}`.trim();
+  const resumoFinal = `${resumoBase}\n${resumoExperiencias ?? 'Sem experiências informadas'}`.trim();
   const candidatoAtualizado = await tx.candidato.update({
     where: { id: candidatoId },
     data: { resumo: resumoFinal },
@@ -109,6 +109,7 @@ export async function gerarResumoExperiencia(tx: Prisma.TransactionClient, candi
   });
 
   await gerarEmbeddingCandidato(tx, candidatoAtualizado, resumoFinal);
+  return candidatoAtualizado;
 }
 
 async function criarEmbedding(texto: string) {

--- a/src/utils/matchUtils.ts
+++ b/src/utils/matchUtils.ts
@@ -100,8 +100,8 @@ export async function gerarResumoExperiencia(tx: Prisma.TransactionClient, candi
       Local da experiência: ${exp.local}.`;
     })
     .join('\n');
-
-  const resumoFinal = `${candidato.resumo}\n${resumoExperiencias}`.trim();
+  const resumoBase = gerarResumoCandidato(candidato);
+  const resumoFinal = `${resumoBase}\n${resumoExperiencias}`.trim();
   const candidatoAtualizado = await tx.candidato.update({
     where: { id: candidatoId },
     data: { resumo: resumoFinal },

--- a/src/utils/matchUtils.ts
+++ b/src/utils/matchUtils.ts
@@ -4,6 +4,7 @@ import { Prisma } from '@prisma/client';
 import prisma from './prisma';
 import { VagaCreateDTO, VagaResponseDTO } from '../models/VagaSchema';
 import { CandidatoCreateDTO, CandidatoExtendedResponseDTO } from '../models/CandidatoSchema';
+import { ExperienciaResponseDTO } from '../models/ExperienciaSchema';
 
 export interface Similaridade {
   id: number;
@@ -86,6 +87,29 @@ export function gerarResumoVaga(vaga: VagaCreateDTO) {
 export async function gerarEmbeddingVaga(tx: Prisma.TransactionClient, vaga: VagaResponseDTO, textoEmbedding: string) {
   const embedding = await criarEmbedding(textoEmbedding);
   await atualizarEmbedding(tx, 'Vaga', vaga.id, embedding.values);
+}
+
+export async function gerarResumoExperiencia(
+  tx: Prisma.TransactionClient,
+  experiencia: ExperienciaResponseDTO,
+  candidatoId: number,
+) {
+  const { titulo, descricao, orientador, instituicao, periodoInicio, periodoFim, local } = experiencia;
+  const resumo = `O candidato possui experiência de ${titulo} na instituição ${instituicao}, orientada por ${orientador}. Descrição da experiência: ${descricao}. Atuou no Período: ${periodoInicio} a ${periodoFim ? periodoFim : 'atualmente'}. Local da experiência: ${local}.`;
+
+  await atualizarResumoCandidato(tx, candidatoId, resumo);
+}
+
+async function atualizarResumoCandidato(tx: Prisma.TransactionClient, candidatoId: number, resumo: string) {
+  const candidato = await prisma.candidato.findUnique({ where: { id: candidatoId }, include: { perfil: true } });
+  if (!candidato) return;
+  const resumoCandidato = `${candidato.resumo}\nExperiência: ${resumo}`;
+  const candidatoAtualizado = await tx.candidato.update({
+    where: { id: candidatoId },
+    data: { resumo: resumoCandidato },
+    include: { perfil: true },
+  });
+  gerarEmbeddingCandidato(tx, candidatoAtualizado, resumoCandidato);
 }
 
 async function criarEmbedding(texto: string) {

--- a/test/services/CandidatoService.test.ts
+++ b/test/services/CandidatoService.test.ts
@@ -68,6 +68,10 @@ const makeCandidatoResponse = (overrides = {}) => ({
   areasInteresse: ['DESENVOLVIMENTO_WEB', 'IA'],
   habilidades: ['INGLES', 'JAVASCRIPT', 'JAVA', 'REACT'],
   perfil: makePerfilResponse(),
+  resumo: `Profissional/Estudante da instituição UFCG com foco em Ciência da Computação. 
+    Nível de escolaridade: SUPERIOR_INCOMPLETO, com conclusão prevista para 202612. 
+    Competências e conhecimentos técnicos: INGLES, JAVASCRIPT, JAVA, REACT. Áreas de interesse e objetivos: DESENVOLVIMENTO_WEB, IA.
+    Disponibilidade de tempo: 20.`,
   ...overrides,
 });
 

--- a/test/services/VagaService.test.ts
+++ b/test/services/VagaService.test.ts
@@ -81,7 +81,9 @@ const makeVagaResponse = (overrides = {}) => ({
   publicoAlvo: ['ALUNO_GRADUACAO'],
   conhecimentosObrigatorios: ['JavaScript', 'TypeScript'],
   conhecimentosOpcionais: ['React', 'Node.js'],
-
+  resumo: `Oportunidade de Estágio em Desenvolvimento de Software na instituição UFCG. Perfil da Vaga: Descrição da vaga....
+    Formação requerida: Ciência da Computação para o público ALUNO_GRADUACAO. Requisitos técnicos mandatórios: JavaScript, TypeScript.
+    Desejável e diferenciais: React, Node.js. Condições: Carga horária de 20 e duração de 6 meses.`,
   ...overrides,
 });
 


### PR DESCRIPTION

[x] Adicionar novo campo resumo para ser considerado na busca da barra de pesquisa.
[x] Esse campo será preenchido ao realizar o cadastro, e atualizado sempre que o perfil/vaga for editado.
[x] Considerar também as experiências do usuário no campo?

<img width="609" height="245" alt="image" src="https://github.com/user-attachments/assets/2fed5394-68fc-413b-bacb-37f6f0124d2b" />


1. Sempre que um vaga/candidato é cadastrado o resumo é gerado e enviado na response do candidato
2. Sempre que um candidato é atualizado o resumo é reconstruído
3. Sempre que uma vaga é atualizada, o resumo é salvo novamente
4. Sempre que a experiencia é criada, atualizada ou deletada, o resumo é reconstruído 
